### PR TITLE
Add podspec for CocoaPods

### DIFF
--- a/HighlightedWebView.podspec
+++ b/HighlightedWebView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "HighlightedWebView"
-  s.version      = "0.0.1"
+  s.version      = "1.0.0"
   s.summary      = "WebView subclass that highlights all search results (Safari-style wannabe)"
 
   s.description  = <<-DESC
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.social_media_url = "http://twitter.com/kapeli"
 
   s.platform         = :osx
-  s.source           = { :git => "https://github.com/Kapeli/HighlightedWebView.git", :commit => "748b95dd1e677b94d37c1ae19c4f720b279f359f" }
+  s.source           = { :git => "https://github.com/Kapeli/HighlightedWebView.git", :tag => "1.0.0" }
 
   s.source_files     = "HighlightedWebView/*.{h,m}"
   s.exclude_files    = "HighlightedWebView/DHAppDelegate.h", "HighlightedWebView/DHAppDelegate.m", "HighlightedWebView/main.m"


### PR DESCRIPTION
It would be nice to have tags on the repo in order to identity future releases. By default, CocoaPods uses `0.0.1`, but that’s really not ideal.

---

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```
